### PR TITLE
feat: opt binary size for `minimal` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,18 @@ tls = ["tokio-native-tls"]
 noise = ["snowstorm", "base64"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[profile.release]
+lto = true
+
 [profile.bench]
 debug = 1
 
 [profile.minimal]
 inherits = "release"
-opt-level = "s"
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ rathole, like [frp](https://github.com/fatedier/frp), can help to expose the ser
 - **Low Resource Consumption** Much less memory is consumed and well managed by Rust.
 - **Secure Model** Tokens of services are mandatory and service-wise. The server and clients are responsible for their own configs.
 - **Encryption** With the help of the Noise Protocol, encryption can be configured at ease. No need to create a self-signed certificate!
-- **Flexibility** While the default profile produces a small binary, it can be customized to be even smaller to fit the constraints of devices, like embedded devices as routers.
+- **Optimized Binary** While small enough by default, `rathole` can be customized to be **as small as ~500KiB** to fit the constraints of devices, like embedded devices as routers.
 
 ## Quickstart
 

--- a/docs/build-guide.md
+++ b/docs/build-guide.md
@@ -1,0 +1,41 @@
+# Build Guide
+This is for those who want to build `rathole` themselves, possibly because the need of latest features or the minimal binary size.
+
+## Build
+To use default build settings, run:
+```
+cargo build --release
+```
+
+## Customize the build
+`rathole` comes with lots of *crate features* that determine whether a certain feature will be compiled or not. Supported features can be checked out in `Cargo.toml`.
+
+For example, to build `rathole` with the `client` and `noise` feature:
+```
+cargo build --release --no-default-features --features client,noise
+```
+
+## Minimalize the binary
+
+1. Build with the `minimal` profile
+
+The `release` build profile optimize for the program running time, not the binary size. 
+
+However, the `minimal` profile enables lots of optimization for the binary size to produce a much smaller binary.
+
+For example, to build `rathole` with `client` feature with the `minimal` profile:
+```
+cargo build --profile minimal --no-default-features --features client
+```
+
+2. `strip` and `upx`
+
+The binary that step 1 produces can be even smaller, by using `strip` and `upx` to remove the symbols and compress the binary.
+
+Like:
+```
+strip rathole
+upx --best --lzma rathole
+```
+
+At the time of writting the build guide, the produced binary for `x86_64-unknown-linux-glibc` has the size of **574 KiB**, while `frpc` has the size of **~10 MiB**, which is much larger.


### PR DESCRIPTION
This can reduce a binary with feature `client` **from 3 MiB to 500KiB**, which is impressive!