### PR TITLE
fix: update build script for using vergen without a git repo

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,13 @@ fn main() -> Result<()> {
     *config.git_mut().semver_kind_mut() = SemverKind::Lightweight;
     // Add a `-dirty` flag to the SEMVER output
     *config.git_mut().semver_dirty_mut() = Some("-dirty");
-
     // Generate the instructions
-    vergen(config)
+    if let Err(e) = vergen(config) {
+        eprintln!("error occurred while generating instructions: {:?}", e);
+        let mut config = Config::default();
+        *config.git_mut().enabled_mut() = false;
+        vergen(config)
+    } else {
+        Ok(())
+    }
 }


### PR DESCRIPTION
Hey! Recently I tried to build `rathole` from the source tarball and got this error:

```
   Compiling rathole v0.3.1 (/build/rathole/src/rathole-0.3.1)
error: failed to run custom build command for `rathole v0.3.1 (/build/rathole/src/rathole-0.3.1)`

Caused by:
  process didn't exit successfully: `/build/rathole/src/rathole-0.3.1/target/release/build/rathole-b8f03abef0c5fe3e/build-script-build` (exit status: 1)
  --- stderr
  Error: could not find repository from '/build/rathole/src/rathole-0.3.1'; class=Repository (6); code=NotFound (-3)
warning: build failed, waiting for other jobs to finish...
error: build failed

```

This PR fixes this issue by running `vergen` twice if it fails, with disabling the "git" feature. This won't be an issue since `option_env!` is used for these git-related variables.

References:
- https://github.com/rustyhorde/vergen/issues/101
- https://github.com/rustyhorde/vergen/issues/64#issuecomment-826489559

