### PR TITLE
chore: reduce crate size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/rapiz1/rathole"
 readme = "README.md"
 build = "build.rs"
+include = ["src/**/*", "LICENSE", "README.md", "build.rs"]
 
 [features]
 default = ["server", "client", "tls", "noise", "hot-reload"]


### PR DESCRIPTION
remove unused file in crate

see also https://github.com/the-lean-crate/criner#the-criner-waste-report
```
┌───────────────────────────────────────────────────────────┬─────────────┐
│ Removed File                                              │ Size (Byte) │
├───────────────────────────────────────────────────────────┼─────────────┤
│ .rustfmt.toml                                             │          31 │
│ .gitignore                                                │          32 │
│ .dockerignore                                             │         101 │
│ examples/minimal/server.toml                              │         109 │
│ examples/minimal/client.toml                              │         114 │
│ examples/udp/server.toml                                  │         122 │
│ examples/udp/client.toml                                  │         127 │
│ tests/config_test/invalid_config/missing_tls_server2.toml │         148 │
│ tests/config_test/invalid_config/missing_tls_client.toml  │         156 │
│ examples/iperf3/server.toml                               │         198 │
│ tests/config_test/invalid_config/missing_tls_server.toml  │         202 │
│ examples/iperf3/client.toml                               │         204 │
│ examples/tls/server.toml                                  │         226 │
│ examples/systemd/rathole@.service                         │         230 │
│ examples/tls/client.toml                                  │         232 │
│ examples/noise_nk/server.toml                             │         236 │
│ examples/systemd/ratholes@.service                        │         240 │
│ examples/systemd/ratholec@.service                        │         240 │
│ examples/noise_nk/client.toml                             │         241 │
│ examples/systemd/ratholes.service                         │         245 │
│ examples/systemd/ratholec.service                         │         245 │
│ examples/unified/config.toml                              │         314 │
│ Dockerfile                                                │         327 │
│ tests/for_tcp/tcp_transport.toml                          │         467 │
│ benches/scripts/mem/plot.plt                              │         486 │
│ tests/for_udp/tcp_transport.toml                          │         519 │
│ tests/for_tcp/tls_transport.toml                          │         638 │
│ tests/for_tcp/noise_transport.toml                        │         655 │
│ benches/scripts/http/latency.sh                           │         677 │
│ tests/for_udp/tls_transport.toml                          │         690 │
│ tests/for_udp/noise_transport.toml                        │         707 │
│ benches/scripts/mem/mem.sh                                │         899 │
│ docs/out-of-scope.md                                      │        1179 │
│ examples/systemd/README.md                                │        1322 │
│ docs/build-guide.md                                       │        1413 │
│ docs/internals.md                                         │        1438 │
│ .github/workflows/rust.yml                                │        1908 │
│ examples/tls/ca-cert.pem                                  │        2199 │
│ tests/config_test/valid_config/full.toml                  │        2492 │
│ tests/common/mod.rs                                       │        2883 │
│ docs/benchmark.md                                         │        3183 │
│ .github/workflows/release.yml                             │        3613 │
│ docs/security.md                                          │        3905 │
│ docs/img/mem-graph.png                                    │        4661 │
│ examples/tls/identity.pfx                                 │        5885 │
│ tests/integration_test.rs                                 │        7379 │
│ README-zh.md                                              │        8030 │
│ docs/img/rathole-logo.png                                 │       28370 │
│ docs/img/overview.excalidraw                              │       33955 │
│ docs/img/udp_bitrate.svg                                  │       55516 │
│ docs/img/http_throughput.svg                              │       57565 │
│ docs/img/tcp_bitrate.svg                                  │       63499 │
│ docs/img/overview.png                                     │      155129 │
└───────────────────────────────────────────────────────────┴─────────────┘
```
Saved 80% or 455.6 KB in 53 files (of 571.2 KB and 72 files in entire crate)
