### PR TITLE
feat: make `accept` cancel safe and add a timeout

### DIFF
--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -10,13 +10,15 @@ use tokio::net::ToSocketAddrs;
 #[async_trait]
 pub trait Transport: Debug + Send + Sync {
     type Acceptor: Send + Sync;
+    type RawStream: Send + Sync;
     type Stream: 'static + AsyncRead + AsyncWrite + Unpin + Send + Sync + Debug;
 
     async fn new(config: &TransportConfig) -> Result<Self>
     where
         Self: Sized;
     async fn bind<T: ToSocketAddrs + Send + Sync>(&self, addr: T) -> Result<Self::Acceptor>;
-    async fn accept(&self, a: &Self::Acceptor) -> Result<(Self::Stream, SocketAddr)>;
+    async fn accept(&self, a: &Self::Acceptor) -> Result<(Self::RawStream, SocketAddr)>;
+    async fn handshake(&self, conn: Self::RawStream) -> Result<Self::Stream>;
     async fn connect(&self, addr: &str) -> Result<Self::Stream>;
 }
 

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -14,6 +14,7 @@ pub struct TcpTransport {}
 impl Transport for TcpTransport {
     type Acceptor = TcpListener;
     type Stream = TcpStream;
+    type RawStream = TcpStream;
 
     async fn new(_config: &TransportConfig) -> Result<Self> {
         Ok(TcpTransport {})
@@ -23,10 +24,14 @@ impl Transport for TcpTransport {
         Ok(TcpListener::bind(addr).await?)
     }
 
-    async fn accept(&self, a: &Self::Acceptor) -> Result<(Self::Stream, SocketAddr)> {
+    async fn accept(&self, a: &Self::Acceptor) -> Result<(Self::RawStream, SocketAddr)> {
         let (s, addr) = a.accept().await?;
         set_tcp_keepalive(&s);
         Ok((s, addr))
+    }
+
+    async fn handshake(&self, conn: Self::RawStream) -> Result<Self::Stream> {
+        Ok(conn)
     }
 
     async fn connect(&self, addr: &str) -> Result<Self::Stream> {


### PR DESCRIPTION
- Make `Transport::accept` cancel safe. Resolves https://github.com/rapiz1/rathole/issues/84
- Add a timeout for transport handshake.