### PR TITLE
fix: use exp backoff for running control channel

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -14,3 +14,11 @@ pub fn listen_backoff() -> ExponentialBackoff {
         ..Default::default()
     }
 }
+
+pub fn run_control_chan_backoff() -> ExponentialBackoff {
+    ExponentialBackoff {
+        max_elapsed_time: None,
+        max_interval: Duration::from_secs(1),
+        ..Default::default()
+    }
+}


### PR DESCRIPTION
Current backoff is always 1s, which is too long if the channel is broken due to a transient network interrupt. Use exponential backoff to make the reconnecting more frequently.