### PR TITLE
fix: link aginst glibc instead of muslc on mips32

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,10 @@ jobs:
             target: armv7-unknown-linux-musleabihf
             exe: rathole
           - os: ubuntu-latest
-            target: mips-unknown-linux-musl
+            target: mips-unknown-linux-gnu
             exe: rathole
           - os: ubuntu-latest
-            target: mipsel-unknown-linux-musl
+            target: mipsel-unknown-linux-gnu
             exe: rathole
           - os: ubuntu-latest
             target: mips64-unknown-linux-gnuabi64


### PR DESCRIPTION
It turns out that `-musl` target for mips32 is dynamically linked and doesn't work for many devices. Use glibc instead.