### PR TITLE
fix(config_watcher): allow backupcopy for vim

### DIFF
--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -138,19 +138,22 @@ async fn config_watcher(
     event_tx: mpsc::UnboundedSender<ConfigChange>,
     mut old: Config,
 ) -> Result<()> {
-    let (fevent_tx, mut fevent_rx) = mpsc::unbounded_channel();
-
+    let (fevent_tx, mut fevent_rx) = mpsc::channel(16);
+    let parent_path = path.parent().expect("config file should have a parent dir");
+    let path_clone = path.clone();
     let mut watcher =
         notify::recommended_watcher(move |res: Result<notify::Event, _>| match res {
             Ok(e) => {
-                if let EventKind::Modify(ModifyKind::Data(_)) = e.kind {
+                if matches!(e.kind, EventKind::Modify(ModifyKind::Data(_)))
+                    && e.paths.get(0).map(|x| x.file_name()).flatten() == path_clone.file_name()
+                {
                     let _ = fevent_tx.send(true);
                 }
             }
             Err(e) => error!("watch error: {:#}", e),
         })?;
 
-    watcher.watch(&path, RecursiveMode::NonRecursive)?;
+    watcher.watch(parent_path, RecursiveMode::NonRecursive)?;
     info!("Start watching the config");
 
     loop {

--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -144,10 +144,13 @@ async fn config_watcher(
     let mut watcher =
         notify::recommended_watcher(move |res: Result<notify::Event, _>| match res {
             Ok(e) => {
-                if matches!(e.kind, EventKind::Modify(ModifyKind::Data(_)))
-                    && e.paths.get(0).map(|x| x.file_name()).flatten() == path_clone.file_name()
+                if matches!(e.kind, EventKind::Modify(_))
+                    && e.paths
+                        .iter()
+                        .map(|x| x.file_name())
+                        .any(|x| x == path_clone.file_name())
                 {
-                    let _ = fevent_tx.send(true);
+                    let _ = fevent_tx.blocking_send(true);
                 }
             }
             Err(e) => error!("watch error: {:#}", e),

--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -138,7 +138,7 @@ async fn config_watcher(
     event_tx: mpsc::UnboundedSender<ConfigChange>,
     mut old: Config,
 ) -> Result<()> {
-    let (fevent_tx, mut fevent_rx) = mpsc::channel(16);
+    let (fevent_tx, mut fevent_rx) = mpsc::unbounded_channel();
     let parent_path = path.parent().expect("config file should have a parent dir");
     let path_clone = path.clone();
     let mut watcher =
@@ -150,7 +150,7 @@ async fn config_watcher(
                         .map(|x| x.file_name())
                         .any(|x| x == path_clone.file_name())
                 {
-                    let _ = fevent_tx.blocking_send(true);
+                    let _ = fevent_tx.send(true);
                 }
             }
             Err(e) => error!("watch error: {:#}", e),

--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -11,7 +11,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::{error, info, instrument};
 
 #[cfg(feature = "notify")]
-use notify::{event::ModifyKind, EventKind, RecursiveMode, Watcher};
+use notify::{EventKind, RecursiveMode, Watcher};
 
 #[derive(Debug, PartialEq)]
 pub enum ConfigChange {


### PR DESCRIPTION
by watching the parent dir of config file, we can receive events regardless of the inode of the config file.

fix #76
