### PR TITLE
Revert "Make CI Workflow faster"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
 
 jobs:
   lints:


### PR DESCRIPTION
Reverts rapiz1/rathole#140

I added a environment variable to `rust.yml` in #140. However, I found that the rust-cache action does this already.