### PR TITLE
Make watcher's path absolute for notify's MacOS fsevent implementation

### DIFF
--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -5,6 +5,7 @@ use crate::{
 use anyhow::{Context, Result};
 use std::{
     collections::HashMap,
+    env,
     path::{Path, PathBuf},
 };
 use tokio::sync::{broadcast, mpsc};
@@ -139,6 +140,11 @@ async fn config_watcher(
     mut old: Config,
 ) -> Result<()> {
     let (fevent_tx, mut fevent_rx) = mpsc::unbounded_channel();
+    let path = if path.is_absolute() {
+        path
+    } else {
+        env::current_dir()?.join(path)
+    };
     let parent_path = path.parent().expect("config file should have a parent dir");
     let path_clone = path.clone();
     let mut watcher =


### PR DESCRIPTION
This is a proposed fix for #154 
I have chosen to replicate the logic present in [notify's inotify implementation](https://github.com/notify-rs/notify/blob/baafb165e4213c3ba3c3e0f2cc19df677888957d/src/inotify.rs#L586). In the notify crate, these checks make it so that there is no error when presenting a watcher with an empty path (`""`) on Linux, but they are missing from MacOS's fsevent implementation, and therefore I propose to always offer the watcher an absolute path.

Another possible solution is to handle the error returned from this call:
```rust
watcher.watch(parent_path, RecursiveMode::NonRecursive)?;
```
using something like
```rust
if let Err(e) = watcher.watch(parent_path, RecursiveMode::NonRecursive) {
  // handle...
}
```
but this means that one could not run rathole on MacOS using this syntax: `rathole config.toml`