### PR TITLE
feat: cache dns result for one session

### DIFF
--- a/src/transport/noise.rs
+++ b/src/transport/noise.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use super::{SocketOpts, TcpTransport, Transport};
+use super::{AddrMaybeCached, SocketOpts, TcpTransport, Transport};
 use crate::config::{NoiseConfig, TransportConfig};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -92,7 +92,7 @@ impl Transport for NoiseTransport {
         Ok(conn)
     }
 
-    async fn connect(&self, addr: &str) -> Result<Self::Stream> {
+    async fn connect(&self, addr: &AddrMaybeCached) -> Result<Self::Stream> {
         let conn = self
             .tcp
             .connect(addr)

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -3,7 +3,7 @@ use crate::{
     helper::tcp_connect_with_proxy,
 };
 
-use super::{SocketOpts, Transport};
+use super::{AddrMaybeCached, SocketOpts, Transport};
 use anyhow::Result;
 use async_trait::async_trait;
 use std::net::SocketAddr;
@@ -46,7 +46,7 @@ impl Transport for TcpTransport {
         Ok(conn)
     }
 
-    async fn connect(&self, addr: &str) -> Result<Self::Stream> {
+    async fn connect(&self, addr: &AddrMaybeCached) -> Result<Self::Stream> {
         let s = tcp_connect_with_proxy(addr, self.cfg.proxy.as_ref()).await?;
         self.socket_opts.apply(&s);
         Ok(s)


### PR DESCRIPTION
Cache the rathole server IP address in the client for one session, which is, a control channel starting up and shutting down. This only affects the client. The server will not cache any DNS queries ( and it shouldn't ).

Resolves https://github.com/rapiz1/rathole/issues/151