### PR TITLE
[example][systemd] use `DynamicUser=yes`

### DIFF
--- a/examples/systemd/rathole@.service
+++ b/examples/systemd/rathole@.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-User=nobody
+DynamicUser=yes
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/rathole /etc/rathole/%i.toml

--- a/examples/systemd/ratholec.service
+++ b/examples/systemd/ratholec.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-User=nobody
+DynamicUser=yes
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/rathole -c /etc/rathole/rathole.toml

--- a/examples/systemd/ratholec@.service
+++ b/examples/systemd/ratholec@.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-User=nobody
+DynamicUser=yes
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/rathole -c /etc/rathole/%i.toml

--- a/examples/systemd/ratholes.service
+++ b/examples/systemd/ratholes.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-User=nobody
+DynamicUser=yes
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/rathole -s /etc/rathole/rathole.toml

--- a/examples/systemd/ratholes@.service
+++ b/examples/systemd/ratholes@.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-User=nobody
+DynamicUser=yes
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/rathole -s /etc/rathole/%i.toml


### PR DESCRIPTION
This patch fixes a warning generated by some new version of systemd. Use
"User=nobody" seems to be considered unsafe. So maybe we need to fix it
in our example files.

```
● ratholec@hitmc.service - Rathole Client Service
     Loaded: loaded (/etc/systemd/system/ratholec@.service; enabled; vendor preset: enabled)
     Active: active (running) since Sat 2022-09-03 23:38:43 CST; 1h 27min ago
   Main PID: 507903 (rathole)
      Tasks: 14 (limit: 76731)
     Memory: 6.9M
        CPU: 39.908s
     CGroup: /system.slice/system-ratholec.slice/ratholec@hitmc.service
             └─507903 /usr/local/bin/rathole -c /etc/rathole/hitmc.toml

Sep 03 23:38:43 <hostname> systemd[1]: Started Rathole Client Service.
...
Sep 03 23:39:25 <hostname> systemd[1]: /etc/systemd/system/ratholec@.service:7: Special user nobody configured, this is not safe!
                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```
Link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=969329
Link: https://github.com/trojan-gfw/trojan/issues/612
Link: https://www.vvave.net/archives/fix-the-systemd-error-special-user-nobody-configured-this-is-not-safe.html
CC: @rapiz1 