### PR TITLE
Allow use of system default TLS trusted root

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -296,11 +296,6 @@ impl Config {
                         .as_ref()
                         .and(tls_config.pkcs12_password.as_ref())
                         .ok_or_else(|| anyhow!("Missing `pkcs12` or `pkcs12_password`"))?;
-                } else {
-                    tls_config
-                        .trusted_root
-                        .as_ref()
-                        .ok_or_else(|| anyhow!("Missing `trusted_root`"))?;
                 }
                 Ok(())
             }

--- a/src/transport/tls.rs
+++ b/src/transport/tls.rs
@@ -42,7 +42,11 @@ impl Transport for TlsTransport {
                     .build()?;
                 Some(TlsConnector::from(connector))
             }
-            None => None,
+            None => {
+                // if no trusted_root is specified, allow TlsConnector to use system default
+                let connector = native_tls::TlsConnector::builder().build()?;
+                Some(TlsConnector::from(connector))
+            },
         };
 
         let tls_acceptor = match config.pkcs12.as_ref() {


### PR DESCRIPTION
Fallback to system default when client config contains no `trusted_root` parameter.