### PR TITLE
ci: upgrade upx to v4.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && !contains(matrix.target, 'mips')
         uses: crazy-max/ghaction-upx@v1
         with:
-          version: v3.96
+          version: v4.0.0
           files: target/${{ matrix.target }}/release/${{ matrix.exe }}
           args: -q --best --lzma
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
upx v4.0.0 is finally released and contains many bugfixes. Let's shift to it.