### PR TITLE
默认的Alpine无法编译通过，需要固定版本

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.69.0-alpine3.17 as builder
+FROM rust:1.66-alpine as builder
 RUN apk add --no-cache musl-dev openssl openssl-dev pkgconfig
 WORKDIR /home/rust/src
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:alpine as builder
+FROM rust:1.69.0-alpine3.17 as builder
 RUN apk add --no-cache musl-dev openssl openssl-dev pkgconfig
 WORKDIR /home/rust/src
 COPY . .


### PR DESCRIPTION
使用最新的版本也无法编译通过；
固定六个月前的版本：1.66-alpine 可以正常编译出Docker Image；

请尝试并合并。