### PR TITLE
Docs/non root user with systemd

### DIFF
--- a/examples/systemd/README.md
+++ b/examples/systemd/README.md
@@ -69,6 +69,6 @@ systemctl --user enable ratholes@app1 --now
 
 ### Run multiple services
 
-To run multiple services at once, simply add another configuration, say `app2` under `/etc/rathole` (`~/.local/etc/rathole` for non-root), then run `sudo systemctl enable ratholes@app1 --now` (`systemctl --user enable ratholes@app2 --now` for non-root) to start an instance for that configuration.
+To run multiple services at once, simply add another configuration, say `app2.toml` under `/etc/rathole` (`~/.local/etc/rathole` for non-root), then run `sudo systemctl enable ratholes@app2 --now` (`systemctl --user enable ratholes@app2 --now` for non-root) to start an instance for that configuration.
 
 The same applies to `ratholec@.service` for `rathole --client` and `rathole@.service` for `rathole`.

--- a/examples/systemd/README.md
+++ b/examples/systemd/README.md
@@ -9,6 +9,8 @@ For the naming of the example, `ratholes` stands for `rathole --server`, and `ra
 
 Assuming that `rathole` is installed in `/usr/bin/rathole`, and the configuration file is in `/etc/rathole/app1.toml`, the following steps shows how to run an instance of `rathole --server`.
 
+For security, it is suggested to store configuration files under `/etc/rathole` with permission `600`, that is, only the root user can read the file, preventing arbitrary users on the system from accessing the secret tokens.
+
 1. Create a service file.
 
 ```bash

--- a/examples/systemd/README.md
+++ b/examples/systemd/README.md
@@ -2,14 +2,16 @@
 
 The directory lists some systemd unit files for example, which can be used to run `rathole` as a service on Linux.
 
-[The `@` symbol in name of unit files](https://superuser.com/questions/393423/the-symbol-and-systemctl-and-vsftpd) such as
+[The `@` symbol in the name of unit files](https://superuser.com/questions/393423/the-symbol-and-systemctl-and-vsftpd) such as
 `rathole@.service` facilitates the management of multiple instances of `rathole`.
 
 For the naming of the example, `ratholes` stands for `rathole --server`, and `ratholec` stands for `rathole --client`, `rathole` is just `rathole`.
 
-Assuming that `rathole` is installed in `/usr/bin/rathole`, and the configuration file is in `/etc/rathole/app1.toml`, the following steps shows how to run an instance of `rathole --server`.
+For security, it is suggested to store configuration files with permission `600`, that is, only the owner can read the file, preventing arbitrary users on the system from accessing the secret tokens.
 
-For security, it is suggested to store configuration files under `/etc/rathole` with permission `600`, that is, only the root user can read the file, preventing arbitrary users on the system from accessing the secret tokens.
+### With root privilege
+
+Assuming that `rathole` is installed in `/usr/bin/rathole`, and the configuration file is in `/etc/rathole/app1.toml`, the following steps show how to run an instance of `rathole --server` with root.
 
 1. Create a service file.
 
@@ -24,14 +26,49 @@ sudo mkdir -p /etc/rathole
 # And create the configuration file named `app1.toml` inside /etc/rathole
 ```
 
-3. Enable and start the service
+3. Enable and start the service.
 
 ```bash
 sudo systemctl daemon-reload # Make sure systemd find the new unit
 sudo systemctl enable ratholes@app1 --now
 ```
 
-And if there's another configuration named `app2.toml` in `/etc/rathole`, then
-`sudo systemctl enable ratholes@app2 --now` can start an instance for that configuration.
+### Without root privilege
 
-The same applies to `rathole --client` and `rathole`.
+Assuming that `rathole` is installed in `~/.local/bin/rathole`, and the configuration file is in `~/.local/etc/rathole/app1.toml`, the following steps show how to run an instance of `rathole --server` without root.
+
+1. Edit the example service file as...
+
+```txt
+# with root
+# ExecStart=/usr/bin/rathole -s /etc/rathole/%i.toml
+# without root
+ExecStart=%h/.local/bin/rathole -s %h/.local/etc/rathole/%i.toml
+```
+
+2. Create a service file.
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp ratholes@.service ~/.config/systemd/user/
+```
+
+3. Create the configuration file `app1.toml`.
+
+```bash
+mkdir -p ~/.local/etc/rathole
+# And create the configuration file named `app1.toml` inside ~/.local/etc/rathole
+```
+
+4. Enable and start the service.
+
+```bash
+systemctl --user daemon-reload # Make sure systemd find the new unit
+systemctl --user enable ratholes@app1 --now
+```
+
+### Run multiple services
+
+To run multiple services at once, simply add another configuration, say `app2` under `/etc/rathole` (`~/.local/etc/rathole` for non-root), then run `sudo systemctl enable ratholes@app1 --now` (`systemctl --user enable ratholes@app2 --now` for non-root) to start an instance for that configuration.
+
+The same applies to `ratholec@.service` for `rathole --client` and `rathole@.service` for `rathole`.

--- a/examples/systemd/rathole@.service
+++ b/examples/systemd/rathole@.service
@@ -4,7 +4,6 @@ After=network.target
 
 [Service]
 Type=simple
-DynamicUser=yes
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/rathole /etc/rathole/%i.toml

--- a/examples/systemd/rathole@.service
+++ b/examples/systemd/rathole@.service
@@ -6,8 +6,12 @@ After=network.target
 Type=simple
 Restart=on-failure
 RestartSec=5s
-ExecStart=/usr/bin/rathole /etc/rathole/%i.toml
 LimitNOFILE=1048576
+
+# with root
+ExecStart=/usr/bin/rathole /etc/rathole/%i.toml
+# without root
+# ExecStart=%h/.local/bin/rathole %h/.local/etc/rathole/%i.toml
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholec.service
+++ b/examples/systemd/ratholec.service
@@ -6,8 +6,12 @@ After=network.target
 Type=simple
 Restart=on-failure
 RestartSec=5s
-ExecStart=/usr/bin/rathole -c /etc/rathole/rathole.toml
 LimitNOFILE=1048576
+
+# with root
+ExecStart=/usr/bin/rathole -c /etc/rathole/rathole.toml
+# without root
+# ExecStart=%h/.local/bin/rathole -c %h/.local/etc/rathole/rathole.toml
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholec.service
+++ b/examples/systemd/ratholec.service
@@ -4,7 +4,6 @@ After=network.target
 
 [Service]
 Type=simple
-DynamicUser=yes
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/rathole -c /etc/rathole/rathole.toml

--- a/examples/systemd/ratholec@.service
+++ b/examples/systemd/ratholec@.service
@@ -6,8 +6,12 @@ After=network.target
 Type=simple
 Restart=on-failure
 RestartSec=5s
-ExecStart=/usr/bin/rathole -c /etc/rathole/%i.toml
 LimitNOFILE=1048576
+
+# with root
+ExecStart=/usr/bin/rathole -c /etc/rathole/%i.toml
+# without root
+# ExecStart=%h/.local/bin/rathole -c %h/.local/etc/rathole/%i.toml
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholec@.service
+++ b/examples/systemd/ratholec@.service
@@ -4,7 +4,6 @@ After=network.target
 
 [Service]
 Type=simple
-DynamicUser=yes
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/rathole -c /etc/rathole/%i.toml

--- a/examples/systemd/ratholes.service
+++ b/examples/systemd/ratholes.service
@@ -6,8 +6,12 @@ After=network.target
 Type=simple
 Restart=on-failure
 RestartSec=5s
-ExecStart=/usr/bin/rathole -s /etc/rathole/rathole.toml
 LimitNOFILE=1048576
+
+# with root
+ExecStart=/usr/bin/rathole -s /etc/rathole/rathole.toml
+# without root
+# ExecStart=%h/.local/bin/rathole -s %h/.local/etc/rathole/rathole.toml
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholes.service
+++ b/examples/systemd/ratholes.service
@@ -4,7 +4,6 @@ After=network.target
 
 [Service]
 Type=simple
-DynamicUser=yes
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/rathole -s /etc/rathole/rathole.toml

--- a/examples/systemd/ratholes@.service
+++ b/examples/systemd/ratholes@.service
@@ -6,8 +6,12 @@ After=network.target
 Type=simple
 Restart=on-failure
 RestartSec=5s
-ExecStart=/usr/bin/rathole -s /etc/rathole/%i.toml
 LimitNOFILE=1048576
+
+# with root
+ExecStart=/usr/bin/rathole -s /etc/rathole/%i.toml
+# without root
+# ExecStart=%h/.local/bin/rathole -s %h/.local/etc/rathole/%i.toml
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholes@.service
+++ b/examples/systemd/ratholes@.service
@@ -4,7 +4,6 @@ After=network.target
 
 [Service]
 Type=simple
-DynamicUser=yes
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/rathole -s /etc/rathole/%i.toml


### PR DESCRIPTION
Related to https://github.com/rapiz1/rathole/pull/186#issuecomment-1611724826.

Quote me,
> A typical use case is storing configurations and tokens under /etc/rathole/xxx.toml with permission set to 0600, that is, only the root user (or owner) can read the file. Preventing arbitrary users on the system from accessing the token. Yet with DynamicUser=yes the rathole process spawned by systemd won't have the privilege to read the file either.

This PR update the document with a more comprehensive systemd setup without root privilege.