### PR TITLE
ci: support apple aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,11 @@ jobs:
             target: x86_64-apple-darwin
             exe: rathole
             cross: false
+          
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            exe: rathole
+            cross: false
 
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -92,7 +97,7 @@ jobs:
         if: matrix.cross == false
         run: rustup target add ${{ matrix.target }}
       - name: Run tests
-        if: matrix.cross == false
+        if: matrix.cross == false && matrix.target != 'aarch64-apple-darwin'
         run: cargo test --release --target ${{ matrix.target }} --verbose 
       - name: Build release
         if: matrix.cross == false 


### PR DESCRIPTION
In this PR, when the target is `aarch64-apple-darwin`, the tests for Native build are bypassed because it seems to fail. However, it can compile successfully and the compiled binary has been tested to run properly on Apple Silicon Mac.

```
➜  ~ file rathole
rathole: Mach-O 64-bit executable arm64
```

I tested the [Actions release](https://github.com/missuo/rathole/actions/runs/6383356395).

