### PR TITLE
Add easy musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
             exe: rathole
             cross: false
           - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            exe: rathole
+            cross: false
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             exe: rathole
             cross: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,8 @@ tokio-tungstenite = { version="0.20.1", optional = true}
 tokio-util = { version="0.7.9", optional = true, features = ["io"] }
 futures-core = { version="0.3.28", optional = true  }
 futures-sink = { version="0.3.28", optional = true }
+
+[target.'cfg(target_env = "musl").dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ tokio-tungstenite = { version="0.20.1", optional = true}
 tokio-util = { version="0.7.9", optional = true, features = ["io"] }
 futures-core = { version="0.3.28", optional = true  }
 futures-sink = { version="0.3.28", optional = true }
+openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
 vergen = { version = "7.4.2", default-features = false, features = ["build", "git", "cargo"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ tokio-util = { version="0.7.9", optional = true, features = ["io"] }
 futures-core = { version="0.3.28", optional = true  }
 futures-sink = { version="0.3.28", optional = true }
 
-[target.'cfg(target_env = "musl").dependencies]
+[target.'cfg(target_env = "musl")'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]


### PR DESCRIPTION
I added dependencies to Cargo, ensuring that OpenSSL is correctly included with features during the compilation of musl, eliminating the need to separately handle OpenSSL for musl. We still find musl necessary because handling dependencies can be quite challenging.
#300 