### PR TITLE
Use tokio_util::sync::CancellationToken to quit service

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::{self, copy_bidirectional, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpStream, UdpSocket};
-use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
+use tokio::sync::{mpsc, oneshot, RwLock};
 use tokio::time::{self, Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, trace, warn, Instrument, Span};

--- a/src/config.rs
+++ b/src/config.rs
@@ -255,9 +255,9 @@ impl Config {
     fn validate_server_config(server: &mut ServerConfig) -> Result<()> {
         // Validate services
         for (name, s) in &mut server.services {
-            s.name = name.clone();
+            s.name.clone_from(name);
             if s.token.is_none() {
-                s.token = server.default_token.clone();
+                s.token.clone_from(&server.default_token);
                 if s.token.is_none() {
                     bail!("The token of service {} is not set", name);
                 }
@@ -272,9 +272,9 @@ impl Config {
     fn validate_client_config(client: &mut ClientConfig) -> Result<()> {
         // Validate services
         for (name, s) in &mut client.services {
-            s.name = name.clone();
+            s.name.clone_from(name);
             if s.token.is_none() {
-                s.token = client.default_token.clone();
+                s.token.clone_from(&client.default_token);
                 if s.token.is_none() {
                     bail!("The token of service {} is not set", name);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use config::Config;
 pub use constants::UDP_BUFFER_SIZE;
 
 use anyhow::Result;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,15 +4,15 @@ use anyhow::Result;
 use tokio::{
     io::{self, AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream, ToSocketAddrs},
-    sync::broadcast,
 };
+use tokio_util::sync::CancellationToken;
 
 pub const PING: &str = "ping";
 pub const PONG: &str = "pong";
 
 pub async fn run_rathole_server(
     config_path: &str,
-    shutdown_rx: broadcast::Receiver<bool>,
+    cancel: CancellationToken,
 ) -> Result<()> {
     let cli = rathole::Cli {
         config_path: Some(PathBuf::from(config_path)),
@@ -20,12 +20,12 @@ pub async fn run_rathole_server(
         client: false,
         ..Default::default()
     };
-    rathole::run(cli, shutdown_rx).await
+    rathole::run(cli, cancel).await
 }
 
 pub async fn run_rathole_client(
     config_path: &str,
-    shutdown_rx: broadcast::Receiver<bool>,
+    cancel: CancellationToken,
 ) -> Result<()> {
     let cli = rathole::Cli {
         config_path: Some(PathBuf::from(config_path)),
@@ -33,7 +33,7 @@ pub async fn run_rathole_client(
         client: true,
         ..Default::default()
     };
-    rathole::run(cli, shutdown_rx).await
+    rathole::run(cli, cancel).await
 }
 
 pub mod tcp {


### PR DESCRIPTION
I see we have used `tokio_util` module, it provides a dedicated way https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html to cancel something.
